### PR TITLE
feat: Implement basic code compiler UI

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,6 +29,11 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor/min/vs",
+                "output": "vs/"
               }
             ],
             "styles": [
@@ -88,6 +93,11 @@
               {
                 "glob": "**/*",
                 "input": "public"
+              },
+              {
+                "glob": "**/*",
+                "input": "node_modules/monaco-editor/min/vs",
+                "output": "vs/"
               }
             ],
             "styles": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,15 @@
         "@angular/platform-browser": "^19.2.0",
         "@angular/platform-browser-dynamic": "^19.2.0",
         "@angular/router": "^19.2.0",
+        "@materia-ui/ngx-monaco-editor": "^6.0.0",
+        "monaco-editor": "^0.52.2",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
         "zone.js": "~0.15.0"
       },
       "devDependencies": {
         "@angular-devkit/build-angular": "^19.2.12",
-        "@angular/cli": "^19.2.12",
+        "@angular/cli": "^19.2.13",
         "@angular/compiler-cli": "^19.2.0",
         "@types/jasmine": "~5.1.0",
         "jasmine-core": "~5.6.0",
@@ -498,7 +500,6 @@
       "resolved": "https://registry.npmjs.org/@angular/cli/-/cli-19.2.13.tgz",
       "integrity": "sha512-dDRCS73/lrItWx9j4SmwHR56GiZsW8ObNi2q9l/1ny813CG9K43STYFG/wJvGS7ZF3y5hvjIiJOwBx2YIouOIw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@angular-devkit/architect": "0.1902.13",
         "@angular-devkit/core": "19.2.13",
@@ -3514,6 +3515,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@materia-ui/ngx-monaco-editor": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@materia-ui/ngx-monaco-editor/-/ngx-monaco-editor-6.0.0.tgz",
+      "integrity": "sha512-gTqNQjOGznZxOC0NlmKdKSGCJuTts8YmK4dsTQAGc5IgIV7cZdQWiW6AL742h0ruED6q0cAunEYjXT6jzHBoIQ==",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": ">=13.0.0",
+        "rxjs": ">=6.0.0"
+      }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
@@ -10408,6 +10421,11 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/monaco-editor": {
+      "version": "0.52.2",
+      "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
+      "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ=="
     },
     "node_modules/mrmime": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -17,13 +17,15 @@
     "@angular/platform-browser": "^19.2.0",
     "@angular/platform-browser-dynamic": "^19.2.0",
     "@angular/router": "^19.2.0",
+    "@materia-ui/ngx-monaco-editor": "^6.0.0",
+    "monaco-editor": "^0.52.2",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^19.2.12",
-    "@angular/cli": "^19.2.12",
+    "@angular/cli": "^19.2.13",
     "@angular/compiler-cli": "^19.2.0",
     "@types/jasmine": "~5.1.0",
     "jasmine-core": "~5.6.0",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,6 +7,11 @@
 <!-- * * * * * * * to get started with your project! * * * * * * * -->
 <!-- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * -->
 
+<nav style="padding: 10px; background-color: #f0f0f0; border-bottom: 1px solid #ccc; margin-bottom: 20px;">
+  <a routerLink="/" style="margin-right: 15px; text-decoration: none; color: #333; font-weight: bold;">Home</a>
+  <a routerLink="/compiler" style="text-decoration: none; color: #333; font-weight: bold;">Compiler</a>
+</nav>
+
 <style>
   :host {
     --bright-blue: oklch(51.01% 0.274 263.83);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,9 +1,9 @@
 import { Component } from '@angular/core';
-import { RouterOutlet } from '@angular/router';
+import { RouterModule, RouterOutlet } from '@angular/router'; // Import RouterModule
 
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet],
+  imports: [RouterOutlet, RouterModule], // Add RouterModule here
   templateUrl: './app.component.html',
   styleUrl: './app.component.scss'
 })

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,6 @@
 import { Routes } from '@angular/router';
+import { CompilerComponent } from './compiler/compiler.component';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+    { path: 'compiler', component: CompilerComponent, title: 'Code Compiler' }
+];

--- a/src/app/compiler-mock.service.spec.ts
+++ b/src/app/compiler-mock.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { CompilerMockService } from './compiler-mock.service';
+
+describe('CompilerMockService', () => {
+  let service: CompilerMockService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(CompilerMockService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/compiler-mock.service.ts
+++ b/src/app/compiler-mock.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class CompilerMockService {
+
+  constructor() { }
+
+  compile(language: string, code: string): Promise<string> {
+    let result: string;
+
+    switch (language.toLowerCase()) {
+      case 'javascript':
+        try {
+          // CAUTION: Using eval() can be dangerous if the code is not trusted.
+          // This is a mock, so we'll proceed with caution.
+          // To make it a bit safer, we'll wrap it in an IIFE and only allow console.log
+          
+          // Store original console.log and create a buffer for logs
+          const originalConsoleLog = console.log;
+          let consoleOutput = '';
+          console.log = (...args: any[]) => {
+            consoleOutput += args.map(String).join(' ') + '\n';
+          };
+
+          eval(`(function() { ${code} })();`);
+          
+          // Restore original console.log
+          console.log = originalConsoleLog;
+          
+          result = consoleOutput || 'JavaScript code executed successfully. No output to console.log.';
+          if (consoleOutput.endsWith('\n')) {
+            result = consoleOutput.slice(0, -1); // Remove trailing newline
+          }
+        } catch (error: any) {
+          result = `JavaScript Error: ${error.message}`;
+        }
+        break;
+      case 'python':
+        result = `Python code received: ${code.substring(0, 50)}${code.length > 50 ? '...' : ''} (mock response)`;
+        break;
+      case 'java':
+      case 'csharp':
+      case 'cpp':
+      default:
+        result = `Mock compilation for ${language}: Code received. (mock response)`;
+        break;
+    }
+    return Promise.resolve(result);
+  }
+}

--- a/src/app/compiler/compiler.component.html
+++ b/src/app/compiler/compiler.component.html
@@ -1,0 +1,27 @@
+<div class="compiler-container">
+  <div class="controls-area">
+    <label for="language-select">Select Language: </label>
+    <select
+      id="language-select"
+      [(ngModel)]="selectedLanguage"
+      (ngModelChange)="onLanguageChange()"
+    >
+      <option *ngFor="let lang of supportedLanguages" [value]="lang">
+        {{ lang }}
+      </option>
+    </select>
+    <button class="compile-button" (click)="compile()">Compile</button>
+  </div>
+
+  <div class="editor-area">
+    <ngx-monaco-editor
+      [options]="editorOptions"
+      [(ngModel)]="code"
+    ></ngx-monaco-editor>
+  </div>
+
+  <div class="output-area">
+    <h3>Output:</h3>
+    <pre class="output-content">{{ output }}</pre>
+  </div>
+</div>

--- a/src/app/compiler/compiler.component.scss
+++ b/src/app/compiler/compiler.component.scss
@@ -1,0 +1,95 @@
+.compiler-container {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 100px); // Example: Adjust based on your app's layout, less header height
+  padding: 15px;
+  gap: 15px; // Space between child elements (controls, editor, output)
+  box-sizing: border-box; // Include padding and border in the element's total width and height
+
+  .controls-area {
+    display: flex;
+    align-items: center;
+    gap: 10px; // Space between label, select, and button
+    padding-bottom: 10px; // Space below the controls
+    border-bottom: 1px solid #eee; // Separator line
+
+    label {
+      font-weight: bold;
+    }
+
+    select {
+      padding: 8px 12px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      background-color: white;
+      font-size: 14px;
+    }
+
+    .compile-button {
+      padding: 8px 15px;
+      background-color: #007bff; // Primary button color
+      color: white;
+      border: none;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 14px;
+      transition: background-color 0.2s ease-in-out;
+
+      &:hover {
+        background-color: #0056b3; // Darker shade on hover
+      }
+
+      &:active {
+        background-color: #004085; // Even darker when pressed
+      }
+    }
+  }
+
+  .editor-area {
+    flex-grow: 1; // Allows the editor to take up available space
+    display: flex; // Needed for ngx-monaco-editor to fill height
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    overflow: hidden; // Ensures the editor respects the border-radius
+
+    ngx-monaco-editor {
+      width: 100%; // Ensure editor component takes full width of its container
+      height: 100%; // Ensure editor component takes full height of its container
+    }
+  }
+
+  .output-area {
+    display: flex;
+    flex-direction: column;
+    min-height: 100px; // Minimum height for the output area
+    max-height: 200px; // Maximum height before scrolling
+    border-top: 1px solid #eee; // Separator line
+    padding-top: 10px; // Space above the output content
+
+    h3 {
+      margin-top: 0;
+      margin-bottom: 8px;
+      font-size: 16px;
+      color: #333;
+    }
+
+    .output-content {
+      flex-grow: 1;
+      background-color: #f8f9fa; // Light background for the output
+      border: 1px solid #e0e0e0;
+      padding: 10px;
+      font-family: "Courier New", Courier, monospace;
+      font-size: 13px;
+      color: #333;
+      overflow-y: auto; // Make it scrollable if content overflows
+      white-space: pre-wrap; // Preserve whitespace and wrap lines
+      border-radius: 4px;
+      margin: 0; // Remove default margin from pre tag
+    }
+  }
+}
+
+// If you have a global styles.scss or styles.css, consider moving some general styles there
+// e.g., body, html { height: 100%; margin: 0; font-family: sans-serif; }
+// to ensure the vh units work as expected and for a consistent look and feel.
+// For this component, we assume its parent container allows it to expand.

--- a/src/app/compiler/compiler.component.spec.ts
+++ b/src/app/compiler/compiler.component.spec.ts
@@ -1,0 +1,143 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { FormsModule } from '@angular/forms';
+import { MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
+import { By } from '@angular/platform-browser';
+import { of, throwError } from 'rxjs'; // Not strictly needed for Promise-based service, but good for async testing
+
+import { CompilerComponent } from './compiler.component';
+import { CompilerMockService } from '../compiler-mock.service';
+
+// Create a mock for CompilerMockService
+class MockCompilerService {
+  compile(language: string, code: string): Promise<string> {
+    if (code === 'throw error') {
+      return Promise.reject('Mock service error');
+    }
+    return Promise.resolve(`Mock compiled ${language}: ${code}`);
+  }
+}
+
+describe('CompilerComponent', () => {
+  let component: CompilerComponent;
+  let fixture: ComponentFixture<CompilerComponent>;
+  let mockCompilerService: CompilerMockService;
+  let compileSpy: jasmine.Spy;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [
+        CompilerComponent, // CompilerComponent is standalone and imports FormsModule and MonacoEditorModule itself
+      ],
+      providers: [
+        { provide: CompilerMockService, useClass: MockCompilerService }
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(CompilerComponent);
+    component = fixture.componentInstance;
+    mockCompilerService = TestBed.inject(CompilerMockService);
+    // Spy on the actual method of the provided service instance
+    compileSpy = spyOn(mockCompilerService, 'compile').and.callThrough();
+    fixture.detectChanges(); // Initial data binding
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('Initial State', () => {
+    it('should have default selectedLanguage as "typescript"', () => {
+      expect(component.selectedLanguage).toBe('typescript');
+    });
+
+    it('should have initial output message', () => {
+      expect(component.output).toBe('Compilation output will appear here.');
+    });
+
+    it('should have default code content for typescript', () => {
+      // Default for typescript is set in constructor via updateEditorOptions
+      // The component initializes with 'typescript', and updateEditorOptions sets default code.
+      // Based on the component's logic:
+      // case 'javascript': this.code = 'console.log("Hello from JavaScript!");'; break;
+      // ...
+      // default: this.code = `// Start typing your ${this.selectedLanguage} code here`;
+      // Since 'typescript' is not explicitly cased for code change, it hits the default.
+      expect(component.code).toBe('// Start typing your typescript code here');
+    });
+
+    it('should have editorOptions for typescript by default', () => { // Corrected syntax: removed extra dot
+        expect(component.editorOptions.language).toBe('typescript');
+    });
+  });
+
+  describe('Language Selection', () => {
+    it('should update selectedLanguage property on dropdown change', () => {
+      const selectElement = fixture.debugElement.query(By.css('#language-select')).nativeElement;
+      selectElement.value = 'python';
+      selectElement.dispatchEvent(new Event('change')); // For native select
+      selectElement.dispatchEvent(new Event('ngModelChange')); // For ngModel
+      fixture.detectChanges();
+      expect(component.selectedLanguage).toBe('python');
+    });
+
+    it('should call updateEditorOptions when selectedLanguage changes', () => {
+      spyOn(component as any, 'updateEditorOptions').and.callThrough(); // Spy on private method
+      component.selectedLanguage = 'python';
+      component.onLanguageChange(); // Manually trigger as ngModelChange might not be enough in test
+      expect((component as any).updateEditorOptions).toHaveBeenCalled();
+    });
+
+    it('updateEditorOptions should update editorOptions.language and set default code', () => {
+      component.selectedLanguage = 'python';
+      (component as any).updateEditorOptions(); // Call private method
+      expect(component.editorOptions.language).toBe('python');
+      expect(component.code).toBe('print("Hello from Python!")');
+
+      component.selectedLanguage = 'javascript';
+      (component as any).updateEditorOptions();
+      expect(component.editorOptions.language).toBe('javascript');
+      expect(component.code).toBe('console.log("Hello from JavaScript!");');
+    });
+  });
+
+  describe('Compile Action', () => {
+    it('should call compile() method when "Compile" button is clicked', () => {
+      spyOn(component, 'compile').and.callThrough();
+      const compileButton = fixture.debugElement.query(By.css('.compile-button')).nativeElement;
+      compileButton.click();
+      expect(component.compile).toHaveBeenCalled();
+    });
+
+    it('compile() method should call compilerMockService.compile() with correct language and code', fakeAsync(() => {
+      component.selectedLanguage = 'python';
+      component.code = 'print("test")';
+      component.compile();
+      tick(); // Resolve promises
+      expect(compileSpy).toHaveBeenCalledWith('python', 'print("test")');
+    }));
+
+    it('should update output property with mock success response', fakeAsync(() => {
+      component.selectedLanguage = 'javascript';
+      component.code = 'console.log("success")';
+      component.compile();
+      tick(); // Wait for the promise to resolve
+      expect(component.output).toBe('Mock compiled javascript: console.log("success")');
+    }));
+
+    it('should update output property with mock error message on service error', fakeAsync(() => {
+      component.selectedLanguage = 'javascript';
+      component.code = 'throw error'; // Mock service will throw error for this code
+      component.compile();
+      tick(); // Wait for the promise to resolve/reject
+      expect(component.output).toBe('Error during compilation: Mock service error');
+    }));
+
+    it('should set "No code to compile." if code is empty or whitespace', fakeAsync(() => {
+      component.code = '   ';
+      component.compile();
+      tick();
+      expect(component.output).toBe('No code to compile.');
+      expect(compileSpy).not.toHaveBeenCalled();
+    }));
+  });
+});

--- a/src/app/compiler/compiler.component.ts
+++ b/src/app/compiler/compiler.component.ts
@@ -1,0 +1,68 @@
+import { Component } from '@angular/core';
+import { MonacoEditorModule } from '@materia-ui/ngx-monaco-editor';
+import { FormsModule } from '@angular/forms'; // Required for ngModel
+import { CompilerMockService } from '../compiler-mock.service'; // Import the mock service
+
+@Component({
+  selector: 'app-compiler',
+  standalone: true,
+  imports: [MonacoEditorModule, FormsModule],
+  templateUrl: './compiler.component.html',
+  styleUrl: './compiler.component.scss',
+  providers: [CompilerMockService] // Add service to providers if not using root injection or a module
+})
+export class CompilerComponent {
+  editorOptions = {theme: 'vs-dark', language: 'typescript'};
+  code: string = '// Start typing your TypeScript code here\nfunction greet() {\n  console.log("Hello, world!");\n}\ngreet();';
+
+  supportedLanguages: string[] = ['typescript', 'javascript', 'python', 'java', 'csharp', 'cpp'];
+  selectedLanguage: string = 'typescript';
+
+  output: string = 'Compilation output will appear here.';
+
+  constructor(private compilerMockService: CompilerMockService) { // Inject the service
+    this.updateEditorOptions(); // Initialize editor options
+  }
+
+  onLanguageChange(): void {
+    this.updateEditorOptions();
+  }
+
+  private updateEditorOptions(): void {
+    this.editorOptions = { ...this.editorOptions, language: this.selectedLanguage };
+    // Update boilerplate code based on language
+    switch (this.selectedLanguage) {
+      case 'javascript':
+        this.code = 'console.log("Hello from JavaScript!");';
+        break;
+      case 'python':
+        this.code = 'print("Hello from Python!")';
+        break;
+      case 'java':
+        this.code = 'public class Main {\n  public static void main(String[] args) {\n    System.out.println("Hello from Java!");\n  }\n}';
+        break;
+      case 'csharp':
+        this.code = 'using System;\n\npublic class Hello\n{\n  public static void Main(string[] args)\n  {\n    Console.WriteLine("Hello from C#!");\n  }\n}';
+        break;
+      case 'cpp':
+        this.code = '#include <iostream>\n\nint main() {\n  std::cout << "Hello from C++!" << std::endl;\n  return 0;\n}';
+        break;
+      default:
+        this.code = `// Start typing your ${this.selectedLanguage} code here`;
+    }
+  }
+
+  async compile(): Promise<void> {
+    if (!this.code.trim()) {
+      this.output = 'No code to compile.';
+      return;
+    }
+    this.output = `Compiling ${this.selectedLanguage} code...`;
+    try {
+      const result = await this.compilerMockService.compile(this.selectedLanguage, this.code);
+      this.output = result;
+    } catch (error: any) {
+      this.output = `Error during compilation: ${error.message || error}`;
+    }
+  }
+}


### PR DESCRIPTION
Adds a new 'Compiler' page to the application with the following features:

- Monaco-based code editor.
- Language selection dropdown (supports TypeScript, JavaScript, Python, Java, C#, C++).
- Default boilerplate code for selected language.
- "Compile" button to simulate code compilation.
- Output display area for compilation results.
- Mock `CompilerMockService` to simulate backend compilation:
    - JavaScript code is evaluated using `eval()` and console output is captured.
    - Other languages return predefined mock responses.
- Basic styling for an IDE-like layout.
- Unit tests for the CompilerComponent covering language selection, compilation logic, and initial state.
- Routing and navigation link to access the new compiler interface.